### PR TITLE
ConsumedOffset is handled incorrectly when an OffsetOutOfRange error is received by the fetcher

### DIFF
--- a/src/KafkaNET.Library/Consumers/FetcherRunnable.cs
+++ b/src/KafkaNET.Library/Consumers/FetcherRunnable.cs
@@ -106,7 +106,11 @@ namespace Kafka.Client.Consumers
                             switch (messages.ErrorCode)
                             {
                                 case (short)ErrorMapping.NoError:
-                                    partitionTopicInfo.ConsumedOffsetOutOfRange = false;
+                                    if (partitionTopicInfo.ConsumedOffsetOutOfRange)
+                                    {
+                                        partitionTopicInfo.ConsumedOffsetOutOfRange = false;
+                                    }
+
                                     int bytesRead = partitionTopicInfo.Add(messages);
                                     // TODO: The highwater offset on the message set is the end of the log partition. If the message retrieved is -1 of that offset, we are at the end.
                                     if (messages.Messages.Any())


### PR DESCRIPTION
When FetcherRunnable detects about outOfRange, it tries to fix the issue by bump up both fectedoffset and consumedoffset ahead to the valid one. As Fetcher thread don't own and shouldn't own the consumedoffset, the consumerIterator who is the actual owner of consumedoffset update the consumedoffset back to the position it actually consumed. In the next iteration of Fetcher thread, it detects that the lag between fectedoffset consumedoffset is big enough so it stop fetching more. It is true during normal case, but it is not true when the fetchedoffset being manually set ahead instead of fetched ahead.
The fix is first, FetcherRunnable shouldn't just set the consumedoffset as it doesn't own how far it consumed. When FetcherRunnable detects about outofrange error, it signal PartitionTopicInfo about ConsumedOffsetOutOfRange error and cleared the fetcher buffer as those buffered message are invalid on broker. During the next iteration of the fetcher thread, if the lag is big enough or there is outofrange error, keep fetching. When it successfully fetched, it can clear the ConsumedOffsetOutOfRange error in PartitionTopicInfo.
